### PR TITLE
Update app versions; apply vsdx import workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,22 @@ ARG BASE_IMAGE=alpine:3.20.3
 
 FROM $BASE_IMAGE AS builder
 
-ARG SHA512SUM_1=aecbc4ae16f6783e3f80696fe936c8201fd74a708be18a2512864c0141eeec91180b8c8274f60a0e28390d932344a15c5ef3b3e6fbb819b3d2db244d4f562998
-ARG SHA512SUM_2=016b4ec30120198b75083bf842fc8de9866d78a6cfa6d006161ebc7a6c7a4218dbf5566e382c9a104ec6bc96cfdb7e310e3400b3c0dd58cc703fa6dfd427a47e
+ARG SHA512SUM_1=a46c8e37d4767b56a16dbdd8e81b80f25ad2edd5fba68b5099b9165cfffbe32bc923a601db8bb5cba50e8b1047a7906eb8c30ca176e1c0b8dfd85fbb9c54c6c2
+ARG SHA512SUM_2=15f60e7918ec8c735e566defccab84b7d913f1d2518f48ae43985191a6b7d06da729107d0d3c58aa59651863018366443388960f1826b2546d4e6c59291abb7c
 
 RUN apk add --no-cache wget tar \
-    && wget https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.48/bin/apache-tomcat-10.1.48.tar.gz \
-    && echo "$SHA512SUM_1  apache-tomcat-10.1.48.tar.gz" | sha512sum -c - \
+    && wget https://dlcdn.apache.org/tomcat/tomcat-10/v10.1.49/bin/apache-tomcat-10.1.49.tar.gz \
+    || wget https://archive.apache.org/dist/tomcat/tomcat-10/v10.1.49/bin/apache-tomcat-10.1.49.tar.gz \
+    && echo "$SHA512SUM_1  apache-tomcat-10.1.49.tar.gz" | sha512sum -c - \
     && mkdir -p /opt/tomcat \
-    && tar xzf apache-tomcat-10.1.48.tar.gz -C /opt/tomcat --strip-components 1 \
-    && rm apache-tomcat-10.1.48.tar.gz
+    && tar xzf apache-tomcat-10.1.49.tar.gz -C /opt/tomcat --strip-components 1 \
+    && rm apache-tomcat-10.1.49.tar.gz
 
-RUN wget https://github.com/jgraph/drawio/releases/download/v28.2.5/draw.war \
+RUN wget https://github.com/jgraph/drawio/releases/download/v29.0.3/draw.war \
     && echo "$SHA512SUM_2  draw.war" | sha512sum -c - \
         && rm -fr /opt/tomcat/webapps/* \
     && unzip draw.war -d /opt/tomcat/webapps/_diagram \
+    && wget https://app.diagrams.net/js/extensions.min.js -O /opt/tomcat/webapps/_diagram/js/extensions.min.js \
     && ln -sf /opt/tomcat/webapps/_diagram /opt/tomcat/webapps/ROOT \
     && rm -rf draw.war
 


### PR DESCRIPTION
The `js/extensions.min.js` in the GitHub-released code of drawio misses method doImportVisio. The workaround aims at fixing it, see https://github.com/jgraph/drawio/issues/5073#issuecomment-3533625106

ERM36873
ERM44631

[5.1.x]

For the difference of the GitHub version and the version in the workaround:
```
$ wget https://github.com/jgraph/drawio/releases/download/v29.0.3/draw.war
$ unzip draw.war -d /tmp/drawio && cd /tmp/drawio/js
$ grep "doImportVisio" -rin extensions.min.js                                                                  
$ docker exec -it bluespice-diagram grep "doImportVisio" -rin /opt/tomcat/webapps/_diagram/js/extensions.min.js
4641:EditorUi.prototype.doImportVisio=function(g,t,r,u){u=u||g.name;null!=u&&/(\.vs(x|sx?))($|\?)/i.test(u)?(new com.mxgraph.io.mxVssxCodec(this)).decodeVssx(g,t,null,r):(new com.mxgraph.io.mxVsdxCodec(this)).decodeVsdx(g,t,null,r)};
```
It is for sure not nice to wget some remote content without checking sha512sum, though the published `extensions.min.js` might change anytime. Maybe we can find a better way applying this workaround. 